### PR TITLE
Rename stylesheet_link_tag to standard and correct landing point for tab trigger

### DIFF
--- a/stylesheet_link_tag-(slt).sublime-snippet
+++ b/stylesheet_link_tag-(slt).sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <content><![CDATA[${TM_RAILS_TEMPLATE_START_RUBY_EXPR}stylesheet_link_tag ${1::application}${2:, media: "${3:all}"}${4:, cache: ${5:true}}${TM_RAILS_TEMPLATE_END_RUBY_EXPR}]]></content>
+    <tabTrigger>slt</tabTrigger>
+    <scope>text.html.ruby, text.haml</scope>
+    <description>stylesheet_link_tag</description>
+</snippet>

--- a/stylesheet_link_tag.sublime-snippet
+++ b/stylesheet_link_tag.sublime-snippet
@@ -1,6 +1,0 @@
-<snippet>
-    <content><![CDATA[${TM_RAILS_TEMPLATE_START_RUBY_EXPR}stylesheet_link_tag ${1::application}${2:, media: ${3:"all"}}${TM_RAILS_TEMPLATE_END_RUBY_EXPR}]]></content>
-    <tabTrigger>slt</tabTrigger>
-    <scope>text.html.ruby, text.haml</scope>
-    <description>stylesheet_link_tag</description>
-</snippet>


### PR DESCRIPTION
1. Renamed tag to standard
2. Added cache option
3. Changed landing position of tab trigger (lands within the quotes)
