### PR TITLE
Fix escaping and unescaping evaluation characters

### DIFF
--- a/Ruby Haml.tmLanguage
+++ b/Ruby Haml.tmLanguage
@@ -90,7 +90,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>$|(?!\.|#|\{|\[|!?=|-|~|/)</string>
+			<string>$|(?!\.|#|\{|\[|[&amp;!]?=|-|~|/)</string>
 			<key>patterns</key>
 			<array>
 				<dict>
@@ -169,7 +169,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>^\s*(?=!?=|-|~)</string>
+			<string>^\s*(?=[&amp;!]?=|-|~)</string>
 			<key>end</key>
 			<string>$</string>
 			<key>patterns</key>
@@ -199,7 +199,7 @@
 		<key>rubyline</key>
 		<dict>
 			<key>begin</key>
-			<string>!?=|-|~</string>
+			<string>[&amp;!]?=|-|~</string>
 			<key>contentName</key>
 			<string>source.ruby.embedded.haml</string>
 			<key>end</key>


### PR DESCRIPTION
Haml syntax supports !=, &= and ! to change escaping for string interpolation: http://haml.info/docs/yardoc/file.REFERENCE.html#escaping_html

Problem is, this syntax file doesn't understand this and highlights the Ruby code as plain text.  Ugly!

This set of patches fixes it.  Submitted in separate patches so, despite the complexity of the regexes, the intent is perfectly clear.

Submitted to you because, alas, Sublime's Rails support is being neglected and now looks truly antique. I really hope your changes make it upstream!
